### PR TITLE
:bug: Trim `.git` suffixes

### DIFF
--- a/hosting_service/services/github_com.ts
+++ b/hosting_service/services/github_com.ts
@@ -45,7 +45,7 @@ export const service: HostingService = {
 
 function formatURLBase(fetchURL: URL): string {
   const [owner, repo] = fetchURL.pathname.split("/").slice(1);
-  return `https://${fetchURL.hostname}/${owner}/${repo}`;
+  return `https://${fetchURL.hostname}/${owner}/${repo.replace(/\.git$/, "")}`;
 }
 
 function formatSuffix(range: Range | undefined): string {


### PR DESCRIPTION
Before: returns `https://github.com/peacock0803sz/deno-git-browse.git/tree/main`
After: returns `https://github.com/peacock0803sz/deno-git-browse/tree/main`