### PR TITLE
Use `git config` to get remote name, instead of `git branch` command

### DIFF
--- a/commit_url.ts
+++ b/commit_url.ts
@@ -12,7 +12,7 @@ export async function getCommitURL(
   options: Options = {},
 ): Promise<URL> {
   if (!options.remote) {
-    const remote = await getRemoteContains(commitish, options);
+    const remote = await getRemoteContains(options);
     return getCommitURL(commitish, { ...options, remote: remote ?? "origin" });
   }
   const fetchURL = await getRemoteFetchURL(options.remote, options);

--- a/home_url.ts
+++ b/home_url.ts
@@ -11,7 +11,7 @@ export async function getHomeURL(
   options: Options = {},
 ): Promise<URL> {
   if (!options.remote) {
-    const remote = await getRemoteContains("HEAD", options);
+    const remote = await getRemoteContains(options);
     return getHomeURL({ ...options, remote: remote ?? "origin" });
   }
   const fetchURL = await getRemoteFetchURL(options.remote, options);

--- a/object_url.ts
+++ b/object_url.ts
@@ -14,7 +14,7 @@ export async function getObjectURL(
   options: Options = {},
 ): Promise<URL> {
   if (!options.remote) {
-    const remote = await getRemoteContains(commitish, options);
+    const remote = await getRemoteContains(options);
     return getObjectURL(commitish, path, {
       ...options,
       remote: remote ?? "origin",

--- a/pull_request_url.ts
+++ b/pull_request_url.ts
@@ -12,7 +12,7 @@ export async function getPullRequestURL(
   options: Options = {},
 ): Promise<URL> {
   if (!options.remote) {
-    const remote = await getRemoteContains(commitish, options);
+    const remote = await getRemoteContains(options);
     return getPullRequestURL(commitish, {
       ...options,
       remote: remote ?? "origin",

--- a/util.ts
+++ b/util.ts
@@ -1,19 +1,15 @@
-import { common } from "https://deno.land/std@0.194.0/path/mod.ts";
 import { execute, ExecuteOptions } from "./process.ts";
 
 export async function getRemoteContains(
-  commitish: string,
+  _: string,
   options: ExecuteOptions = {},
 ): Promise<string | undefined> {
   const stdout = await execute(
-    ["branch", "-r", "--contains", commitish, "--format=%(refname:short)"],
+    // ref: https://git-scm.com/docs/git-config/2.30.0#Documentation/git-config.txt-clonedefaultRemoteName
+    ["config", "--default", "origin", "--get", "clone.defaultRemoteName"],
     options,
   );
-  const result = common(stdout.trim().split("\n"));
-  if (!result) {
-    return undefined;
-  }
-  return result?.substring(0, result.length - 1);
+  return stdout.trim().split("\n").at(0);
 }
 
 export async function getRemoteFetchURL(

--- a/util.ts
+++ b/util.ts
@@ -1,7 +1,6 @@
 import { execute, ExecuteOptions } from "./process.ts";
 
 export async function getRemoteContains(
-  _: string,
   options: ExecuteOptions = {},
 ): Promise<string | undefined> {
   const stdout = await execute(


### PR DESCRIPTION
fix: #9 

It would be better to use use `git config` to get remote name, instead of `git branch` command.
`git config --default origin --get clone.defaultRemoteName` returns default branch name or `origin` (if not set)

ref: https://git-scm.com/docs/git-config/2.30.0#Documentation/git-config.txt-clonedefaultRemoteName

## Test result

```
$ deno -V
deno 1.37.1

$ deno test -A .
running 2 tests from ./hosting_service/mod_test.ts
getHostingService ...
  getHomeURL for ssh://git@github.com/lambdalisue/gin.vim ... ok (3ms)
  getCommitURL for ssh://git@github.com/lambdalisue/gin.vim ... ok (0ms)
  getTreeURL for ssh://git@github.com/lambdalisue/gin.vim ... ok (0ms)
  getBlobURL for ssh://git@github.com/lambdalisue/gin.vim ... ok (0ms)
  getBlobURL with lineStart for ssh://git@github.com/lambdalisue/gin.vim ... ok (1ms)
  getBlobURL with lineStart/lineEnd for ssh://git@github.com/lambdalisue/gin.vim ... ok (0ms)
  getPullRequestURL for ssh://git@github.com/lambdalisue/gin.vim ... ok (0ms)
  getHomeURL for https://github.com/lambdalisue/gin.vim ... ok (0ms)
  getCommitURL for https://github.com/lambdalisue/gin.vim ... ok (0ms)
  getTreeURL for https://github.com/lambdalisue/gin.vim ... ok (0ms)
  getBlobURL for https://github.com/lambdalisue/gin.vim ... ok (0ms)
  getBlobURL with lineStart for https://github.com/lambdalisue/gin.vim ... ok (0ms)
  getBlobURL with lineStart/lineEnd for https://github.com/lambdalisue/gin.vim ... ok (0ms)
  getPullRequestURL for https://github.com/lambdalisue/gin.vim ... ok (0ms)
getHostingService ... ok (7ms)
getHostingService with alias ...
  getHomeURL for https://my-github.com/lambdalisue/gin.vim ... ok (0ms)
  getCommitURL for https://my-github.com/lambdalisue/gin.vim ... ok (0ms)
  getTreeURL for https://my-github.com/lambdalisue/gin.vim ... ok (0ms)
  getBlobURL for https://my-github.com/lambdalisue/gin.vim ... ok (0ms)
  getBlobURL with lineStart for https://my-github.com/lambdalisue/gin.vim ... ok (0ms)
  getBlobURL with lineStart/lineEnd for https://my-github.com/lambdalisue/gin.vim ... ok (0ms)
  getPullRequestURL for https://my-github.com/lambdalisue/gin.vim ... ok (0ms)
getHostingService with alias ... ok (1ms)
running 2 tests from ./process_test.ts
execute() runs 'git' and return a stdout on success ... ok (17ms)
execute() runs 'git' and throw ExecuteError on fail ... ok (26ms)

ok | 4 passed (21 steps) | 0 failed (129ms)
```