### PR TITLE
:bug: Fix getRemoteDefaultBranch regexp

### DIFF
--- a/pull_request_url.ts
+++ b/pull_request_url.ts
@@ -88,7 +88,7 @@ async function getRemoteDefaultBranch(
     ["remote", "show", remote],
     options,
   );
-  const m = stdout.match(/HEAD branch: (.*)$/);
+  const m = stdout.match(/HEAD branch: (.*)/);
   if (!m) {
     return undefined;
   }


### PR DESCRIPTION
stdout has multiple lines, so `$` is not necessary for the method.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
    - Improved pattern matching in output processing for more accuracy.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->