### PR TITLE
:+1: Use `with` instead of `assert` for `import` options.

### DIFF
--- a/bin/browse.ts
+++ b/bin/browse.ts
@@ -59,7 +59,7 @@ export async function readAliasesFile(): Promise<Record<string, string>> {
   }
   try {
     return await import(join(cdir, "browse", "aliases.json"), {
-      assert: { type: "json" },
+      with: { type: "json" },
     });
   } catch (err) {
     if (err instanceof TypeError) {


### PR DESCRIPTION
SSIA

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Improved the JSON file import process for reading aliases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->