### PR TITLE
:bug: Avoid using `https://` imports

### DIFF
--- a/bin/browse.ts
+++ b/bin/browse.ts
@@ -1,9 +1,9 @@
 #!/usr/bin/env -S deno run --allow-run --allow-read --allow-env
-import { parse } from "https://deno.land/std@0.194.0/flags/mod.ts";
-import { join } from "https://deno.land/std@0.194.0/path/mod.ts";
-import { ensure, is } from "https://deno.land/x/unknownutil@v3.2.0/mod.ts";
-import { systemopen } from "https://deno.land/x/systemopen@v0.2.0/mod.ts";
-import config_dir from "https://deno.land/x/dir@1.5.1/config_dir/mod.ts";
+import { parse } from "jsr:@std/flags";
+import { join } from "jsr:@std/path";
+import { ensure, is } from "jsr:@core/unknownutil";
+import { systemopen } from "jsr:@lambdalisue/systemopen";
+import { dir } from "jsr:@cross/dir";
 import {
   getCommitAbbrevRef,
   getCommitSHA1,
@@ -53,7 +53,7 @@ export async function getURL(
 }
 
 export async function readAliasesFile(): Promise<Record<string, string>> {
-  const cdir = config_dir();
+  const cdir = await dir("config");
   if (!cdir) {
     return {};
   }

--- a/hosting_service/mod_test.ts
+++ b/hosting_service/mod_test.ts
@@ -1,5 +1,5 @@
-import { assertThrows } from "https://deno.land/std@0.202.0/assert/mod.ts";
-import { assertSnapshot } from "https://deno.land/std@0.202.0/testing/snapshot.ts";
+import { assertThrows } from "jsr:@std/assert";
+import { assertSnapshot } from "jsr:@std/testing/snapshot";
 import { getHostingService, UnsupportedHostingServiceError } from "./mod.ts";
 
 Deno.test("getHostingService", async (t) => {

--- a/hosting_service/services/bitbucket_org.ts
+++ b/hosting_service/services/bitbucket_org.ts
@@ -1,6 +1,6 @@
 import type { HostingService, Range } from "../mod.ts";
 import type { ExecuteOptions } from "../../process.ts";
-import { extname } from "https://deno.land/std@0.202.0/path/mod.ts";
+import { extname } from "jsr:@std/path";
 import { getCommitSHA1 } from "../../util.ts";
 
 export const service: HostingService = {

--- a/process_test.ts
+++ b/process_test.ts
@@ -1,7 +1,4 @@
-import {
-  assert,
-  assertRejects,
-} from "https://deno.land/std@0.194.0/testing/asserts.ts";
+import { assert, assertRejects } from "jsr:@std/assert";
 import { execute, ExecuteError } from "./process.ts";
 
 Deno.test("execute() runs 'git' and return a stdout on success", async () => {

--- a/util_test.ts
+++ b/util_test.ts
@@ -1,8 +1,5 @@
-import { stub } from "https://deno.land/std@0.202.0/testing/mock.ts";
-import {
-  assertEquals,
-  unreachable,
-} from "https://deno.land/std@0.202.0/assert/mod.ts";
+import { stub } from "jsr:@std/testing/mock";
+import { assertEquals, unreachable } from "jsr:@std/assert";
 import { _internals, ExecuteError } from "./process.ts";
 import {
   getCommitAbbrevRef,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Refactor**
	- Updated import paths across various files to use custom aliases and modules for improved maintainability and consistency.
- **Tests**
	- Modified test files to reference custom module paths, aligning with the new import strategy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->